### PR TITLE
Prevent JD dual submission and implement related UI feedback

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,7 +15,7 @@ function App() {
       content: "",
     },
   });
-  const [jobUploaded, setJobUploaded] = useState(false);
+  const [jobFileUploaded, setJobFileUploaded] = useState(false);
   const [jobTextUploaded, setJobTextUploaded] = useState(false);
   const [job, setJob] = useState({
     file: {
@@ -111,7 +111,7 @@ function App() {
         content: "",
       },
     });
-    setJobUploaded(false);
+    setJobFileUploaded(false);
     setJobTextUploaded(false);
     setJob({
       file: {
@@ -126,10 +126,16 @@ function App() {
     toast.success("Inputs cleared successfully!");
   };
 
+  // Effect to validate JD input
+  useEffect(() => {
+    if (jobFileUploaded && jobTextUploaded) {
+      toast.error("Please upload either a JD file or paste text, not both.");
+    }
+  }, [jobFileUploaded, jobTextUploaded]);
+
   const analyzeHandler = async () => {
     try {
-      // For now, prioritize file content over text content
-      const jobContent = job.file.content || job.text.content;
+      const jobContent = jobFileUploaded ? job.file.content : job.text.content;
 
       const api_response = await fetch(`${apiUrl}/analyze`, {
         method: "POST",
@@ -168,8 +174,10 @@ function App() {
         clearTrigger={clearTrigger}
       />
       <JobUpload
-        uploadHandler={(e) => uploadHandler(e, "job", setJobUploaded, setJob)}
-        uploaded={jobUploaded}
+        uploadHandler={(e) =>
+          uploadHandler(e, "job", setJobFileUploaded, setJob)
+        }
+        uploaded={jobFileUploaded}
         textUploaded={jobTextUploaded}
         filename={job.file.filename}
         onTextSubmit={handleJobTextSubmit}
@@ -178,13 +186,17 @@ function App() {
       <button
         className="clear-button"
         onClick={clearSubmissions}
-        disabled={!(resumeUploaded || jobUploaded || jobTextUploaded)}
+        disabled={!(resumeUploaded || jobFileUploaded || jobTextUploaded)}
       >
         Clear Submissions
       </button>
       <button
         className="analyze-button"
-        disabled={!(resumeUploaded && (jobUploaded || jobTextUploaded))}
+        disabled={
+          !resumeUploaded ||
+          !(jobFileUploaded || jobTextUploaded) ||
+          (jobFileUploaded && jobTextUploaded)
+        }
         onClick={analyzeHandler}
       >
         Analyze

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -50,11 +50,11 @@ function App() {
     if (!file) return;
 
     const formData = new FormData();
-    formData.append(type, file);
+    formData.append("document", file);
 
     const capitalizedType = type.charAt(0).toUpperCase() + type.slice(1);
     try {
-      const api_response = await fetch(`${apiUrl}/upload-${type}`, {
+      const api_response = await fetch(`${apiUrl}/upload-document`, {
         method: "POST",
         body: formData,
       });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -88,14 +88,18 @@ function App() {
   };
 
   const handleJobTextSubmit = (text) => {
-    setJobTextUploaded(true);
+    setJobTextUploaded(!!text.trim());
     setJob((prev) => ({
-      ...prev, // Retain the file content if it exists
+      ...prev,
       text: {
         content: text,
       },
     }));
-    toast.success("Job description text submitted successfully!");
+    toast.success(
+      text.trim()
+        ? "Job description text submitted successfully!"
+        : "Job description text cleared.",
+    );
   };
 
   const analyzeHandler = async () => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,6 +28,7 @@ function App() {
   });
   const [analysisResults, setAnalysisResults] = useState(false);
   const [showResults, setShowResults] = useState(false);
+  const [clearTrigger, setClearTrigger] = useState(false);
 
   /*
   useEffect(() => {
@@ -102,6 +103,29 @@ function App() {
     );
   };
 
+  const clearSubmissions = () => {
+    setResumeUploaded(false);
+    setResume({
+      file: {
+        filename: "",
+        content: "",
+      },
+    });
+    setJobUploaded(false);
+    setJobTextUploaded(false);
+    setJob({
+      file: {
+        filename: "",
+        content: "",
+      },
+      text: {
+        content: "",
+      },
+    });
+    setClearTrigger((prev) => !prev);
+    toast.success("Inputs cleared successfully!");
+  };
+
   const analyzeHandler = async () => {
     try {
       // For now, prioritize file content over text content
@@ -141,6 +165,7 @@ function App() {
         }
         uploaded={resumeUploaded}
         filename={resume.file.filename}
+        clearTrigger={clearTrigger}
       />
       <JobUpload
         uploadHandler={(e) => uploadHandler(e, "job", setJobUploaded, setJob)}
@@ -148,7 +173,15 @@ function App() {
         textUploaded={jobTextUploaded}
         filename={job.file.filename}
         onTextSubmit={handleJobTextSubmit}
+        clearTrigger={clearTrigger}
       />
+      <button
+        className="clear-button"
+        onClick={clearSubmissions}
+        disabled={!(resumeUploaded || jobUploaded || jobTextUploaded)}
+      >
+        Clear Submissions
+      </button>
       <button
         className="analyze-button"
         disabled={!(resumeUploaded && (jobUploaded || jobTextUploaded))}

--- a/frontend/src/Components/JobUpload/JobUpload.jsx
+++ b/frontend/src/Components/JobUpload/JobUpload.jsx
@@ -28,7 +28,7 @@ function JobUpload({
         type="file"
         className="file-input"
         onChange={uploadHandler}
-        key={`file-${clearTrigger ? "clear" : "normal"}`}
+        key={`job-${clearTrigger ? "version-1" : "version-2"}`}
       />
       <textarea
         ref={textAreaRef}
@@ -36,7 +36,7 @@ function JobUpload({
         className="text-input"
         value={text}
         onChange={handleTextChange}
-        key={`text-${clearTrigger ? "clear" : "normal"}`}
+        key={`text-${clearTrigger ? "version-1" : "version-2"}`}
       />
       <button
         type="button"

--- a/frontend/src/Components/JobUpload/JobUpload.jsx
+++ b/frontend/src/Components/JobUpload/JobUpload.jsx
@@ -51,13 +51,14 @@ function JobUpload({
           {uploaded && textUploaded ? (
             <motion.span
               key="both"
-              className="upload-status"
+              className="upload-status-warning"
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -10 }}
               transition={{ duration: 0.3 }}
             >
-              ✅ Both file ({filename}) and text submitted
+              ⚠️ Both file ({filename}) and text submitted — choose only one to
+              submit
             </motion.span>
           ) : uploaded ? (
             <motion.span

--- a/frontend/src/Components/JobUpload/JobUpload.jsx
+++ b/frontend/src/Components/JobUpload/JobUpload.jsx
@@ -1,5 +1,5 @@
 import { motion, AnimatePresence } from "motion/react";
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 
 function JobUpload({
   uploadHandler,
@@ -7,8 +7,20 @@ function JobUpload({
   filename,
   onTextSubmit,
   textUploaded,
+  clearTrigger,
 }) {
   const [text, setText] = useState("");
+  const fileInputRef = useRef(null);
+  const textAreaRef = useRef(null);
+
+  useEffect(() => {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+    if (textAreaRef.current) {
+      setText("");
+    }
+  }, [clearTrigger]);
 
   const handleTextChange = (e) => setText(e.target.value);
   const handleTextSubmit = () => onTextSubmit(text);
@@ -16,12 +28,20 @@ function JobUpload({
   return (
     <div className="upload-section">
       <h2>Job Description Upload</h2>
-      <input type="file" className="file-input" onChange={uploadHandler} />
+      <input
+        ref={fileInputRef}
+        type="file"
+        className="file-input"
+        onChange={uploadHandler}
+        key={`file-${clearTrigger ? "clear" : "normal"}`}
+      />
       <textarea
+        ref={textAreaRef}
         placeholder="Or paste job description here..."
         className="text-input"
         value={text}
         onChange={handleTextChange}
+        key={`text-${clearTrigger ? "clear" : "normal"}`}
       />
       <button
         type="button"

--- a/frontend/src/Components/JobUpload/JobUpload.jsx
+++ b/frontend/src/Components/JobUpload/JobUpload.jsx
@@ -28,7 +28,6 @@ function JobUpload({
         className="text-submit-button"
         style={{ marginTop: 8, marginBottom: 0 }}
         onClick={handleTextSubmit}
-        disabled={!text.trim()}
       >
         Submit Text
       </button>

--- a/frontend/src/Components/JobUpload/JobUpload.jsx
+++ b/frontend/src/Components/JobUpload/JobUpload.jsx
@@ -1,4 +1,4 @@
-import { motion } from "motion/react";
+import { motion, AnimatePresence } from "motion/react";
 import { useState } from "react";
 
 function JobUpload({
@@ -37,38 +37,50 @@ function JobUpload({
         Submit Text
       </button>
       <div style={{ minHeight: 24, display: "flex", alignItems: "center" }}>
-        {uploaded && textUploaded ? (
-          <motion.span
-            className="upload-status"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.5 }}
-          >
-            ✅ Both file ({filename}) and text submitted
-          </motion.span>
-        ) : uploaded ? (
-          <motion.span
-            className="upload-status"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.5 }}
-          >
-            ✅ Uploaded: {filename}
-          </motion.span>
-        ) : textUploaded ? (
-          <motion.span
-            className="upload-status"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.5 }}
-          >
-            ✅ Text input received
-          </motion.span>
-        ) : (
-          <span style={{ opacity: 0 }} className="upload-status">
-            placeholder
-          </span>
-        )}
+        <AnimatePresence mode="wait">
+          {uploaded && textUploaded ? (
+            <motion.span
+              key="both"
+              className="upload-status"
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -10 }}
+              transition={{ duration: 0.3 }}
+            >
+              ✅ Both file ({filename}) and text submitted
+            </motion.span>
+          ) : uploaded ? (
+            <motion.span
+              key="file"
+              className="upload-status"
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -10 }}
+              transition={{ duration: 0.3 }}
+            >
+              ✅ Uploaded: {filename}
+            </motion.span>
+          ) : textUploaded ? (
+            <motion.span
+              key="text"
+              className="upload-status"
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -10 }}
+              transition={{ duration: 0.3 }}
+            >
+              ✅ Text input received
+            </motion.span>
+          ) : (
+            <motion.span
+              key="placeholder"
+              style={{ opacity: 0 }}
+              className="upload-status"
+            >
+              placeholder
+            </motion.span>
+          )}
+        </AnimatePresence>
       </div>
     </div>
   );

--- a/frontend/src/Components/JobUpload/JobUpload.jsx
+++ b/frontend/src/Components/JobUpload/JobUpload.jsx
@@ -37,7 +37,16 @@ function JobUpload({
         Submit Text
       </button>
       <div style={{ minHeight: 24, display: "flex", alignItems: "center" }}>
-        {uploaded ? (
+        {uploaded && textUploaded ? (
+          <motion.span
+            className="upload-status"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.5 }}
+          >
+            ✅ Both file ({filename}) and text submitted
+          </motion.span>
+        ) : uploaded ? (
           <motion.span
             className="upload-status"
             initial={{ opacity: 0 }}

--- a/frontend/src/Components/JobUpload/JobUpload.jsx
+++ b/frontend/src/Components/JobUpload/JobUpload.jsx
@@ -10,13 +10,9 @@ function JobUpload({
   clearTrigger,
 }) {
   const [text, setText] = useState("");
-  const fileInputRef = useRef(null);
   const textAreaRef = useRef(null);
 
   useEffect(() => {
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
     if (textAreaRef.current) {
       setText("");
     }
@@ -29,7 +25,6 @@ function JobUpload({
     <div className="upload-section">
       <h2>Job Description Upload</h2>
       <input
-        ref={fileInputRef}
         type="file"
         className="file-input"
         onChange={uploadHandler}

--- a/frontend/src/Components/JobUpload/JobUpload.jsx
+++ b/frontend/src/Components/JobUpload/JobUpload.jsx
@@ -11,11 +11,7 @@ function JobUpload({
   const [text, setText] = useState("");
 
   const handleTextChange = (e) => setText(e.target.value);
-  const handleTextSubmit = () => {
-    if (text.trim()) {
-      onTextSubmit(text);
-    }
-  };
+  const handleTextSubmit = () => onTextSubmit(text);
 
   return (
     <div className="upload-section">

--- a/frontend/src/Components/ResumeUpload/ResumeUpload.jsx
+++ b/frontend/src/Components/ResumeUpload/ResumeUpload.jsx
@@ -2,18 +2,10 @@ import { motion } from "motion/react";
 import { useRef, useEffect } from "react";
 
 function ResumeUpload({ uploadHandler, uploaded, filename, clearTrigger }) {
-  const fileInputRef = useRef(null);
-
-  useEffect(() => {
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
-  }, [clearTrigger]);
   return (
     <div className="upload-section">
       <h2>Resume Upload</h2>
       <input
-        ref={fileInputRef}
         type="file"
         className="file-input"
         onChange={uploadHandler}

--- a/frontend/src/Components/ResumeUpload/ResumeUpload.jsx
+++ b/frontend/src/Components/ResumeUpload/ResumeUpload.jsx
@@ -9,7 +9,7 @@ function ResumeUpload({ uploadHandler, uploaded, filename, clearTrigger }) {
         type="file"
         className="file-input"
         onChange={uploadHandler}
-        key={clearTrigger ? "clear" : "normal"}
+        key={`resume-${clearTrigger ? "version-1" : "version-2"}`}
       />
       <div style={{ minHeight: 24, display: "flex", alignItems: "center" }}>
         {uploaded ? (

--- a/frontend/src/Components/ResumeUpload/ResumeUpload.jsx
+++ b/frontend/src/Components/ResumeUpload/ResumeUpload.jsx
@@ -1,10 +1,24 @@
 import { motion } from "motion/react";
+import { useRef, useEffect } from "react";
 
-function ResumeUpload({ uploadHandler, uploaded, filename }) {
+function ResumeUpload({ uploadHandler, uploaded, filename, clearTrigger }) {
+  const fileInputRef = useRef(null);
+
+  useEffect(() => {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  }, [clearTrigger]);
   return (
     <div className="upload-section">
       <h2>Resume Upload</h2>
-      <input type="file" className="file-input" onChange={uploadHandler} />
+      <input
+        ref={fileInputRef}
+        type="file"
+        className="file-input"
+        onChange={uploadHandler}
+        key={clearTrigger ? "clear" : "normal"}
+      />
       <div style={{ minHeight: 24, display: "flex", alignItems: "center" }}>
         {uploaded ? (
           <motion.span

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -114,10 +114,18 @@ input::file-selector-button:active {
   resize: vertical;
 }
 
-.upload-status {
+.upload-status,
+.upload-status-warning {
   display: block;
   margin-top: 0.5rem;
+}
+
+.upload-status {
   color: #22c55e;
+}
+
+.upload-status-warning {
+  color: #f59e0b;
 }
 
 .analyze-button,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -120,22 +120,42 @@ input::file-selector-button:active {
   color: #22c55e;
 }
 
-.analyze-button {
-  background-color: #3b82f6;
-  color: white;
+.analyze-button,
+.clear-button {
+  background-color: #2b6bd1;
+  border-radius: 12px;
   padding: 0.75rem 1.5rem;
   border: none;
-  border-radius: 8px;
-  font-size: 1rem;
+  color: white;
   cursor: pointer;
-  transition: background-color 0.3s ease;
+  font-size: 1.125rem;
+  transition: all 0.2s ease;
+  width: 100%;
+  max-width: 200px;
 }
 
-.analyze-button:disabled {
+.analyze-button:disabled,
+.clear-button:disabled {
   background-color: #64748b;
   cursor: not-allowed;
+  opacity: 0.7;
 }
 
-.analyze-button:hover:enabled {
-  background-color: #2563eb;
+.analyze-button:not(:disabled):hover {
+  background-color: #2554a3;
+  transform: translateY(-1px);
+}
+
+.clear-button {
+  background-color: #ef4444;
+}
+
+.clear-button:not(:disabled):hover {
+  background-color: #dc2626;
+  transform: translateY(-1px);
+}
+
+.analyze-button:not(:disabled):active,
+.clear-button:not(:disabled):active {
+  transform: translateY(0);
 }

--- a/main.py
+++ b/main.py
@@ -33,25 +33,16 @@ def root():
     return {"message": "Resume Scanner API"}
 
 
-@app.post("/upload-resume")
-async def upload_resume(resume: UploadFile = File(...)):
+@app.post("/upload-document")
+async def upload_document(document: UploadFile = File(...)):
     try:
-        resume_text = extract_text(resume)
-        return {"filename": resume.filename, "content": resume_text}
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-
-
-@app.post("/upload-job")
-async def upload_job(job: UploadFile = File(...)):
-    try:
-        job_text_extracted = extract_text(job)
-        return {"filename": job.filename, "content": job_text_extracted}
+        text = extract_text(document)
+        return {"filename": document.filename, "content": text}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         raise HTTPException(
-            status_code=500, detail=f"Failed to process job PDF: {str(e)}"
+            status_code=500, detail=f"Failed to process document: {str(e)}"
         )
 
 

--- a/main.py
+++ b/main.py
@@ -43,18 +43,16 @@ async def upload_resume(resume: UploadFile = File(...)):
 
 
 @app.post("/upload-job")
-async def upload_job(
-    file: UploadFile = File(None),
-    text: str = Form(None),
-):
+async def upload_job(job: UploadFile = File(...)):
     try:
-        job_text_extracted = extract_text(text)
-        return {"filename": file.filename, "content": job_text_extracted}
+        job_text_extracted = extract_text(job)
+        return {"filename": job.filename, "content": job_text_extracted}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        # Generic fallback (e.g. file encoding error)
-        raise HTTPException(status_code=500, detail="Unexpected error parsing job PDF.")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to process job PDF: {str(e)}"
+        )
 
 
 @app.post("/analyze")


### PR DESCRIPTION
This PR introduces validation logic to prevent users from submitting both a job description PDF and pasted text simultaneously. Key changes include:

- Simplified the `GET /upload-resume` and `GET /upload-job` endpoints to remove raw text processing, and condensing them into one `GET /upload-document` endpoint.
- Disabled Analyze button when both JD inputs are provided.
- Real-time validation with a toast message guiding the user.
- A new "Clear Submissions" button.
- Success and warning messages to give UI feedback on successful résumé and JD submissions.

These changes ensure backend consistency, reduce user confusion, and maintain clean input handling. Validation is handled in the frontend, using existing state values and toast notifications.